### PR TITLE
Change file name prefix of Windows download from 'win32' to 'win'.

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -12,6 +12,8 @@ module.exports = {
 
         if (platform === 'darwin') {
             archivePlatformPrefix = 'mac';
+        } else if (platform === 'win32') {
+            archivePlatformPrefix = 'win';
         }
 
         return `chrome-${archivePlatformPrefix}`;


### PR DESCRIPTION
Currently it's broken on Windows.